### PR TITLE
feat: portfolio v2 — full redesign with Sanity CMS, SEO, and AI projects

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,25 +25,25 @@ export const metadata: Metadata = {
     template: '%s | Felipe Figueiredo',
   },
   description:
-    'Fullstack Developer based in Belo Horizonte, Brazil. Building scalable web applications with React, NestJS, TypeScript, and AI integrations.',
-  keywords: ['Fullstack Developer', 'React', 'NestJS', 'TypeScript', 'Next.js', 'AI', 'Brazil'],
+    'Fullstack Developer based in Belo Horizonte, Brazil. Building scalable web and mobile applications with modern technologies and AI integrations.',
+  keywords: ['Fullstack Developer', 'React', 'React Native', 'Flutter', 'NestJS', 'TypeScript', 'Next.js', 'AI', 'Brazil', 'Mobile', 'Web'],
   authors: [{ name: 'Felipe Figueiredo' }],
   creator: 'Felipe Figueiredo',
-  metadataBase: new URL('https://felipefigueiredo.dev'),
+  metadataBase: new URL('https://felipefigueiredodev.vercel.app'),
   openGraph: {
     type: 'website',
     locale: 'en_US',
-    url: 'https://felipefigueiredo.dev',
+    url: 'https://felipefigueiredodev.vercel.app',
     siteName: 'Felipe Figueiredo',
     title: 'Felipe Figueiredo — Fullstack Developer',
     description:
-      'Fullstack Developer based in Belo Horizonte, Brazil. Building scalable web applications with React, NestJS, TypeScript, and AI integrations.',
+      'Fullstack Developer based in Belo Horizonte, Brazil. Building scalable web and mobile applications with modern technologies and AI integrations.',
   },
   twitter: {
     card: 'summary_large_image',
     title: 'Felipe Figueiredo — Fullstack Developer',
     description:
-      'Fullstack Developer based in Belo Horizonte, Brazil. Building scalable web applications with React, NestJS, TypeScript, and AI integrations.',
+      'Fullstack Developer based in Belo Horizonte, Brazil. Building scalable web and mobile applications with modern technologies and AI integrations.',
     creator: '@felipefigueiredo',
   },
   icons: {
@@ -65,10 +65,10 @@ const jsonLd = {
   '@type': 'Person',
   name: 'Felipe Figueiredo',
   jobTitle: 'Fullstack Developer',
-  url: 'https://felipefigueiredo.dev',
+  url: 'https://felipefigueiredodev.vercel.app',
   sameAs: [
     'https://github.com/FigueiredoFelipe',
-    'https://linkedin.com/in/felipefigueiredo',
+    'https://www.linkedin.com/in/fjnfigueiredo/',
   ],
   address: {
     '@type': 'PostalAddress',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next'
 
-const BASE_URL = 'https://felipefigueiredo.dev'
+const BASE_URL = 'https://felipefigueiredodev.vercel.app'
 
 export default function robots(): MetadataRoute.Robots {
   return {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from 'next'
 import { getAllProjectSlugs } from '@/lib/sanity'
 
-const BASE_URL = 'https://felipefigueiredo.dev'
+const BASE_URL = 'https://felipefigueiredodev.vercel.app'
 
 export const revalidate = 3600
 

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -10,7 +10,7 @@ export default function Footer() {
         </p>
         <div className="flex gap-4">
           <a
-            href="https://linkedin.com/in/felipefigueiredo"
+            href="https://www.linkedin.com/in/fjnfigueiredo/"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="LinkedIn"

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -22,7 +22,7 @@ export default function Contact() {
             fjnfigueiredo@gmail.com
           </a>
           <a
-            href="https://linkedin.com/in/felipefigueiredo"
+            href="https://www.linkedin.com/in/fjnfigueiredo/"
             target="_blank"
             rel="noopener noreferrer"
             aria-label="LinkedIn"

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -68,7 +68,7 @@ export default function Hero({ openToWork }: Props) {
                 <FaGithub size={20} />
               </a>
               <a
-                href="https://linkedin.com/in/felipefigueiredo"
+                href="https://www.linkedin.com/in/fjnfigueiredo/"
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label="LinkedIn"


### PR DESCRIPTION
## Summary

- Complete portfolio v2 redesign with Next.js 15 + React 19 + Sanity v5
- Custom favicon (bracket monogram `<F>`), dark mode, Framer Motion animations
- Sanity CMS integration with 8 seeded projects and AI-generated cover images
- Full SEO metadata: `metadataBase`, Open Graph, JSON-LD Person schema, sitemap, robots
- Fixed all domain URLs (`felipefigueiredodev.vercel.app`) and LinkedIn handle (`fjnfigueiredo`)

## Test plan

- [ ] Homepage loads with hero, about, selected work, contact sections
- [ ] `/projects` lists all 8 projects with cover images
- [ ] `/projects/[slug]` renders project detail with PortableText body
- [ ] Dark mode toggle works with readable contrast
- [ ] LinkedIn links point to correct profile (`/in/fjnfigueiredo/`)
- [ ] `<title>` tag and OG tags use correct domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)