### PR TITLE
fix: style H3 headings in project body

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -116,7 +116,7 @@ export default async function ProjectPage({ params }: Props) {
 
       {project.body && (
         <AnimatedSection delay={0.15}>
-          <div className="prose prose-sm max-w-none text-[var(--text-secondary)] [&_h2]:text-[var(--text-primary)] [&_h2]:font-display [&_h2]:font-semibold [&_a]:text-[var(--text-primary)] [&_a]:underline [&_strong]:text-[var(--text-primary)]">
+          <div className="prose prose-sm max-w-none text-[var(--text-secondary)] [&_h2]:text-[var(--text-primary)] [&_h2]:font-display [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:text-[var(--text-primary)] [&_h3]:font-display [&_h3]:font-semibold [&_h3]:tracking-tight [&_a]:text-[var(--text-primary)] [&_a]:underline [&_strong]:text-[var(--text-primary)]">
             <PortableText value={project.body as Parameters<typeof PortableText>[0]['value']} />
           </div>
         </AnimatedSection>


### PR DESCRIPTION
## Summary
- H3 headings in project detail page body were unstyled — appeared identical to regular text, making the page a wall of text
- Added `font-display`, `font-semibold`, `tracking-tight`, and `text-[var(--text-primary)]` to H3, matching the existing H2 treatment

## Test plan
- [ ] Open any project detail page (e.g. `/projects/strategic-council`)
- [ ] Verify section headings like "Interactive SVG Mandala" are visually distinct from body text

🤖 Generated with [Claude Code](https://claude.com/claude-code)